### PR TITLE
Fix express user type and cleanup AI route

### DIFF
--- a/backend/src/routes/ai/aiRoutes.ts
+++ b/backend/src/routes/ai/aiRoutes.ts
@@ -329,6 +329,6 @@ Focus on making the CV highly competitive for the specific Job Description.
         next(new Error(`Failed to generate AI content: ${message}`));
         return;
     }
-}) /* Removed cast here as per general instruction */);
+});
 
 export default router;

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -9,8 +9,16 @@ export {};
 
 declare global {
   namespace Express {
+    /**
+     * Passport declares an empty `User` interface which results in `req.user`
+     * being typed as `User | undefined`. This overrides that interface so that
+     * both `req.user` and the `User` type itself include the fields we expect
+     * after authentication.
+     */
+    export interface User extends AuthenticatedUser {}
+
     export interface Request {
-      user?: AuthenticatedUser; // Use the imported AuthenticatedUser interface
+      user?: AuthenticatedUser;
     }
   }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -109,5 +109,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- update Express augmentation so `req.user` has proper fields
- simplify closing brace in AI routes
- limit TypeScript compilation to backend src files

## Testing
- `npm test` *(fails: Conversion of type 'User | undefined' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6854708e8814832497f7f46fe1673ee0